### PR TITLE
fix: public npm access, remove reference to projen-eventual in README

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -4,6 +4,7 @@ const project = new typescript.TypeScriptProject({
   name: "@functionless/projen",
   description: "projen templates for Functionless projects",
   releaseToNpm: true,
+  npmAccess: "public",
 
   peerDeps: ["fs-extra", "projen"],
   devDeps: ["@types/fs-extra", "projen"],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ yarn add -D @functionless/projen
 Then apply the `Functionless` component to your project.
 
 ```js
-const { TypescriptProject } = require("projen-eventual");
+const { TypescriptProject } = require("projen");
 const { Functionless } = require("@functionless/projen");
 
 const project = new TypescriptProject({

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [


### PR DESCRIPTION
Unable to publish to NPM right now because of `You must sign up for private packages`. Hoping this is the fix