### PR TITLE
feat: configure TypeScript langauge service for functionless

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,37 @@
+{
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.quickSuggestions": true,
+    "editor.suggest.showReferences": true,
+    "editor.wordWrap": "on"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.formatOnSave": true,
+  "eslint.format.enable": false
+}

--- a/API.md
+++ b/API.md
@@ -101,6 +101,7 @@ public readonly tsProject: TypeScriptProject;
 | <code><a href="#@functionless/projen.Functionless.property.coreDependency">coreDependency</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@functionless/projen.Functionless.property.dependencies">dependencies</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#@functionless/projen.Functionless.property.devDependencies">devDependencies</a></code> | <code>string[]</code> | *No description.* |
+| <code><a href="#@functionless/projen.Functionless.property.languageServiceDependency">languageServiceDependency</a></code> | <code>string</code> | *No description.* |
 
 ---
 
@@ -131,6 +132,16 @@ public readonly devDependencies: string[];
 ```
 
 - *Type:* string[]
+
+---
+
+##### `languageServiceDependency`<sup>Required</sup> <a name="languageServiceDependency" id="@functionless/projen.Functionless.property.languageServiceDependency"></a>
+
+```typescript
+public readonly languageServiceDependency: string;
+```
+
+- *Type:* string
 
 ---
 

--- a/src/component.ts
+++ b/src/component.ts
@@ -7,11 +7,15 @@ import { TypeScriptProject } from "projen/lib/typescript";
  */
 export class Functionless extends Component {
   static readonly coreDependency = "functionless";
+  static readonly languageServiceDependency = "@functionless/language-service";
   static readonly dependencies = [
     Functionless.coreDependency,
     "@aws-cdk/aws-appsync-alpha",
   ];
-  static readonly devDependencies = ["ts-patch"];
+  static readonly devDependencies = [
+    "ts-patch",
+    Functionless.languageServiceDependency,
+  ];
 
   constructor(readonly tsProject: TypeScriptProject) {
     super(tsProject);
@@ -28,6 +32,9 @@ export class Functionless extends Component {
 
       plugins.push({
         transform: `${Functionless.coreDependency}/lib/compile`,
+      });
+      plugins.push({
+        name: Functionless.languageServiceDependency,
       });
 
       compilerOptions.plugins = plugins;

--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -29,5 +29,6 @@ test("add dependency and ts plugin", () => {
   expect((project.tsconfig!.compilerOptions as any).plugins).toEqual([
     { transform: "some other transform" },
     { transform: `${Functionless.coreDependency}/lib/compile` },
+    { name: Functionless.languageServiceDependency },
   ]);
 });

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -17,5 +17,6 @@ test("add dependency and ts plugin", () => {
 
   expect((project.tsconfig!.compilerOptions as any).plugins).toEqual([
     { transform: `${Functionless.coreDependency}/lib/compile` },
+    { name: Functionless.languageServiceDependency },
   ]);
 });


### PR DESCRIPTION
Fixes #3 

Adds https://github.com/functionless/functionless-language-service as a dev dependency and add to the `tsconfig.json` plugins.