### PR TITLE
fix: use SWC and ast-reflection dependencies transitively from functionless

### DIFF
--- a/API.md
+++ b/API.md
@@ -218,21 +218,10 @@ public readonly tsProject: TypeScriptProject;
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@functionless/projen.Functionless.property.astReflectionDependency">astReflectionDependency</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@functionless/projen.Functionless.property.coreDependency">coreDependency</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@functionless/projen.Functionless.property.dependencies">dependencies</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#@functionless/projen.Functionless.property.devDependencies">devDependencies</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#@functionless/projen.Functionless.property.languageServiceDependency">languageServiceDependency</a></code> | <code>string</code> | *No description.* |
-
----
-
-##### `astReflectionDependency`<sup>Required</sup> <a name="astReflectionDependency" id="@functionless/projen.Functionless.property.astReflectionDependency"></a>
-
-```typescript
-public readonly astReflectionDependency: string;
-```
-
-- *Type:* string
 
 ---
 

--- a/src/component.ts
+++ b/src/component.ts
@@ -81,7 +81,6 @@ export interface TypeScriptPlugin {
  */
 export class Functionless extends Component {
   static readonly coreDependency = "functionless";
-  static readonly astReflectionDependency = "@functionless/ast-reflection";
   static readonly languageServiceDependency = "@functionless/language-service";
   static readonly dependencies = [
     Functionless.coreDependency,
@@ -89,11 +88,7 @@ export class Functionless extends Component {
     "typesafe-dynamodb",
   ];
   static readonly devDependencies = [
-    "@swc/cli",
-    "@swc/core@1.2.218",
-    "@swc/register",
     "@swc/jest",
-    Functionless.astReflectionDependency,
     Functionless.languageServiceDependency,
   ];
 


### PR DESCRIPTION
Because the `functionless` repo has strict dependencies on ast-reflection, we are now including them as dependencies https://github.com/functionless/functionless/pull/406

This change removes the addition of these unnecessary dependencies and instead takes a transitive dependencies on SWC and ast-reflection via functionless.